### PR TITLE
Add GridPointForecast function

### DIFF
--- a/noaa.go
+++ b/noaa.go
@@ -28,6 +28,7 @@ type PointsResponse struct {
 	EndpointForecast            string `json:"forecast"`
 	EndpointForecastHourly      string `json:"forecastHourly"`
 	EndpointObservationStations string `json:"observationStations"`
+	EndpointForecastGridData    string `json:"forecastGridData"`
 	Timezone                    string `json:"timeZone"`
 	RadarStation                string `json:"radarStation"`
 }
@@ -60,6 +61,102 @@ type ForecastResponse struct {
 		Details         string  `json:"detailedForecast"`
 	} `json:"periods"`
 	Point *PointsResponse
+}
+
+// GridpointForecastResponse holds the JSON values from /gridpoints/<cwa>/<x,y>"
+// See https://weather-gov.github.io/api/gridpoints for information.
+type GridpointForecastResponse struct {
+	// capture data from the forecast
+	Updated   string `json:"updateTime"`
+	Elevation struct {
+		Value float64 `json:"value"`
+		Units string  `json:"unitCode"`
+	} `json:"elevation"`
+	Weather struct {
+		Values []struct {
+			ValidTime string `json:"validTime"` // ISO 8601 time interval, e.g. 2019-07-04T18:00:00+00:00/PT3H
+			Value     []struct {
+				Coverage  string `json:"coverage"`
+				Weather   string `json:"weather"`
+				Intensity string `json:"intensity"`
+			} `json:"value"`
+		} `json:"values"`
+	} `json:"weather"`
+	Hazards struct {
+		Values []struct {
+			ValidTime string `json:"validTime"` // ISO 8601 time interval, e.g. 2019-07-04T18:00:00+00:00/PT3H
+			Value     []struct {
+				Phenomenon   string `json:"phenomenon"`
+				Significance string `json:"significance"`
+				EventNumber  int32  `json:"event_number"`
+			} `json:"value"`
+		} `json:"values"`
+	} `json:"hazards"`
+	Temperature                      GridpointForecastTimeSeries `json:"temperature"`
+	Dewpoint                         GridpointForecastTimeSeries `json:"dewpoint"`
+	MaxTemperature                   GridpointForecastTimeSeries `json:"maxTemperature"`
+	MinTemperature                   GridpointForecastTimeSeries `json:"minTemperature"`
+	RelativeHumidity                 GridpointForecastTimeSeries `json:"relativeHumidity"`
+	ApparentTemperature              GridpointForecastTimeSeries `json:"apparentTemperature"`
+	HeatIndex                        GridpointForecastTimeSeries `json:"heatIndex"`
+	WindChill                        GridpointForecastTimeSeries `json:"windChill"`
+	SkyCover                         GridpointForecastTimeSeries `json:"skyCover"`
+	WindDirection                    GridpointForecastTimeSeries `json:"windDirection"`
+	WindSpeed                        GridpointForecastTimeSeries `json:"windSpeed"`
+	WindGust                         GridpointForecastTimeSeries `json:"windGust"`
+	ProbabilityOfPrecipitation       GridpointForecastTimeSeries `json:"probabilityOfPrecipitation"`
+	QuantitativePrecipitation        GridpointForecastTimeSeries `json:"quantitativePrecipitation"`
+	iceAccumulation                  GridpointForecastTimeSeries `json:"iceAccumulation"`
+	snowfallAmount                   GridpointForecastTimeSeries `json:"snowfallAmount"`
+	snowLevel                        GridpointForecastTimeSeries `json:"snowLevel"`
+	ceilingHeight                    GridpointForecastTimeSeries `json:"ceilingHeight"`
+	visibility                       GridpointForecastTimeSeries `json:"visibility"`
+	transportWindSpeed               GridpointForecastTimeSeries `json:"transportWindSpeed"`
+	transportWindDirection           GridpointForecastTimeSeries `json:"transportWindDirection"`
+	mixingHeight                     GridpointForecastTimeSeries `json:"mixingHeight"`
+	hainesIndex                      GridpointForecastTimeSeries `json:"hainesIndex"`
+	lightningActivityLevel           GridpointForecastTimeSeries `json:"lightningActivityLevel"`
+	twentyFootWindSpeed              GridpointForecastTimeSeries `json:"twentyFootWindSpeed"`
+	twentyFootWindDirection          GridpointForecastTimeSeries `json:"twentyFootWindDirection"`
+	waveHeight                       GridpointForecastTimeSeries `json:"waveHeight"`
+	wavePeriod                       GridpointForecastTimeSeries `json:"wavePeriod"`
+	waveDirection                    GridpointForecastTimeSeries `json:"waveDirection"`
+	primarySwellHeight               GridpointForecastTimeSeries `json:"primarySwellHeight"`
+	primarySwellDirection            GridpointForecastTimeSeries `json:"primarySwellDirection"`
+	secondarySwellHeight             GridpointForecastTimeSeries `json:"secondarySwellHeight"`
+	secondarySwellDirection          GridpointForecastTimeSeries `json:"secondarySwellDirection"`
+	wavePeriod2                      GridpointForecastTimeSeries `json:"wavePeriod2"`
+	windWaveHeight                   GridpointForecastTimeSeries `json:"windWaveHeight"`
+	dispersionIndex                  GridpointForecastTimeSeries `json:"dispersionIndex"`
+	pressure                         GridpointForecastTimeSeries `json:"pressure"`
+	probabilityOfTropicalStormWinds  GridpointForecastTimeSeries `json:"probabilityOfTropicalStormWinds"`
+	probabilityOfHurricaneWinds      GridpointForecastTimeSeries `json:"probabilityOfHurricaneWinds"`
+	potentialOf15mphWinds            GridpointForecastTimeSeries `json:"potentialOf15mphWinds"`
+	potentialOf25mphWinds            GridpointForecastTimeSeries `json:"potentialOf25mphWinds"`
+	potentialOf35mphWinds            GridpointForecastTimeSeries `json:"potentialOf35mphWinds"`
+	potentialOf45mphWinds            GridpointForecastTimeSeries `json:"potentialOf45mphWinds"`
+	potentialOf20mphWindGusts        GridpointForecastTimeSeries `json:"potentialOf20mphWindGusts"`
+	potentialOf30mphWindGusts        GridpointForecastTimeSeries `json:"potentialOf30mphWindGusts"`
+	potentialOf40mphWindGusts        GridpointForecastTimeSeries `json:"potentialOf40mphWindGusts"`
+	potentialOf50mphWindGusts        GridpointForecastTimeSeries `json:"potentialOf50mphWindGusts"`
+	potentialOf60mphWindGusts        GridpointForecastTimeSeries `json:"potentialOf60mphWindGusts"`
+	grasslandFireDangerIndex         GridpointForecastTimeSeries `json:"grasslandFireDangerIndex"`
+	probabilityOfThunder             GridpointForecastTimeSeries `json:"probabilityOfThunder"`
+	davisStabilityIndex              GridpointForecastTimeSeries `json:"davisStabilityIndex"`
+	atmosphericDispersionIndex       GridpointForecastTimeSeries `json:"atmosphericDispersionIndex"`
+	lowVisibilityOccurrenceRiskIndex GridpointForecastTimeSeries `json:"lowVisibilityOccurrenceRiskIndex"`
+	stability                        GridpointForecastTimeSeries `json:"stability"`
+	redFlagThreatIndex               GridpointForecastTimeSeries `json:"redFlagThreatIndex"`
+	Point                            *PointsResponse
+}
+
+// GridpointForecastTimeSeries holds a series of data from a gridpoint forecast
+type GridpointForecastTimeSeries struct {
+	Uom    string `json:"uom"` // Unit of Measure
+	Values []struct {
+		ValidTime string  `json:"validTime"` // ISO 8601 time interval, e.g. 2019-07-04T18:00:00+00:00/PT3H
+		Value     float64 `json:value"`
+	} `json:"values"`
 }
 
 // Cache used for point lookup to save some HTTP round trips
@@ -97,6 +194,7 @@ func Points(lat string, lon string) (points *PointsResponse, err error) {
 		return pointsCache[endpoint], nil
 	}
 	res, err := apiCall(endpoint)
+
 	if err != nil {
 		return nil, err
 	}
@@ -136,6 +234,26 @@ func Forecast(lat string, lon string) (forecast *ForecastResponse, err error) {
 		return nil, err
 	}
 	res, err := apiCall(point.EndpointForecast)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	decoder := json.NewDecoder(res.Body)
+	if err = decoder.Decode(&forecast); err != nil {
+		return nil, err
+	}
+	forecast.Point = point
+	return forecast, nil
+}
+
+// GridpointForecast returns an array of raw forecast data
+func GridpointForecast(lat string, long string) (forecast *GridpointForecastResponse, err error) {
+	point, err := Points(lat, long)
+	if err != nil {
+		return nil, err
+	}
+	res, err := apiCall(point.EndpointForecastGridData)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This endpoint provides raw numerical forecast data for a 2.5km grid
area. It provides much more detailed information on a longer time frame
than the basic Forecast endpoint.

Documentation can be found at https://weather-gov.github.io/api/gridpoints.

Example:
* [Code](https://hastebin.com/hefaroqabu)
* [Output](https://hastebin.com/raw/elanuduvoz)