### PR TITLE
Missing data in hourly...

### DIFF
--- a/noaa.go
+++ b/noaa.go
@@ -20,7 +20,7 @@ const (
 
 // UserAgent provides the User-Agent header value used for API request.
 // This defaults to the APIKey const value.
-var UserAgent = APIKey
+var userAgent = APIKey
 
 // PointsResponse holds the JSON values from /points/<lat,lon>
 type PointsResponse struct {
@@ -270,7 +270,7 @@ func apiCall(endpoint string) (res *http.Response, err error) {
 		return nil, err
 	}
 	req.Header.Add("Accept", APIAccept)
-	req.Header.Add("User-Agent", UserAgent) // See http://www.weather.gov/documentation/services-web-api
+	req.Header.Add("User-Agent", userAgent) // See http://www.weather.gov/documentation/services-web-api
 
 	res, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -282,6 +282,14 @@ func apiCall(endpoint string) (res *http.Response, err error) {
 		return nil, errors.New("404: data not found for -> " + endpoint)
 	}
 	return res, nil
+}
+
+// SetUserAgent changes the string used for the User-Agent header when making
+// requests.  See https://www.weather.gov/documentation/services-web-api
+// (Authentication) for details.  By default, this library uses APIKey for this
+// value.
+func SetUserAgent(useragent string) {
+	userAgent = useragent
 }
 
 // Points returns a set of useful endpoints for a given <lat,lon>

--- a/noaa.go
+++ b/noaa.go
@@ -18,6 +18,10 @@ const (
 	APIAccept = "application/ld+json"       // Changes may affect struct mappings below
 )
 
+// UserAgent provides the User-Agent header value used for API request.
+// This defaults to the APIKey const value.
+var UserAgent = APIKey
+
 // PointsResponse holds the JSON values from /points/<lat,lon>
 type PointsResponse struct {
 	ID                          string `json:"@id"`
@@ -82,34 +86,36 @@ type ForecastHourlyElevation struct {
 
 // Period holds the JSON values for a period within a forecast response's periods.
 type ForecastResponsePeriod struct {
-	ID              int32   `json:"number"`
-	Name            string  `json:"name"`
-	StartTime       string  `json:"startTime"`
-	EndTime         string  `json:"endTime"`
-	IsDaytime       bool    `json:"isDaytime"`
-	Temperature     float64 `json:"temperature"`
-	TemperatureUnit string  `json:"temperatureUnit"`
-	WindSpeed       string  `json:"windSpeed"`
-	WindDirection   string  `json:"windDirection"`
-	Icon            string  `json:"icon"`
-	Summary         string  `json:"shortForecast"`
-	Details         string  `json:"detailedForecast"`
+	ID               int32   `json:"number"`
+	Name             string  `json:"name"`
+	StartTime        string  `json:"startTime"`
+	EndTime          string  `json:"endTime"`
+	IsDaytime        bool    `json:"isDaytime"`
+	Temperature      float64 `json:"temperature"`
+	TemperatureUnit  string  `json:"temperatureUnit"`
+	TemperatureTrend string  `json:"temperatureTrend"`
+	WindSpeed        string  `json:"windSpeed"`
+	WindDirection    string  `json:"windDirection"`
+	Icon             string  `json:"icon"`
+	Summary          string  `json:"shortForecast"`
+	Details          string  `json:"detailedForecast"`
 }
 
 // ForecastResponsePeriodHourly provides the JSON value for a period within an hourly forecast.
 type ForecastResponsePeriodHourly struct {
-	ID              int32   `json:"number"`
-	Name            string  `json:"name"`
-	StartTime       string  `json:"startTime"`
-	EndTime         string  `json:"endTime"`
-	IsDaytime       bool    `json:"isDaytime"`
-	Temperature     float64 `json:"temperature"`
-	TemperatureUnit string  `json:"temperatureUnit"`
-	WindSpeed       string  `json:"windSpeed"`
-	WindDirection   string  `json:"windDirection"`
-	Icon            string  `json:"icon"`
-	Summary         string  `json:"shortForecast"`
-	Details         string  `json:"detailedForecast"`
+	ID               int32   `json:"number"`
+	Name             string  `json:"name"`
+	StartTime        string  `json:"startTime"`
+	EndTime          string  `json:"endTime"`
+	IsDaytime        bool    `json:"isDaytime"`
+	Temperature      float64 `json:"temperature"`
+	TemperatureUnit  string  `json:"temperatureUnit"`
+	TemperatureTrend string  `json:"temperatureTrend"`
+	WindSpeed        string  `json:"windSpeed"`
+	WindDirection    string  `json:"windDirection"`
+	Icon             string  `json:"icon"`
+	Summary          string  `json:"shortForecast"`
+	Details          string  `json:"detailedForecast"`
 }
 
 // ForecastResponse holds the JSON values from /gridpoints/<cwa>/<x,y>/forecast"
@@ -264,7 +270,7 @@ func apiCall(endpoint string) (res *http.Response, err error) {
 		return nil, err
 	}
 	req.Header.Add("Accept", APIAccept)
-	req.Header.Add("User-Agent", APIKey) // See http://www.weather.gov/documentation/services-web-api
+	req.Header.Add("User-Agent", UserAgent) // See http://www.weather.gov/documentation/services-web-api
 
 	res, err = http.DefaultClient.Do(req)
 	if err != nil {

--- a/noaa.go
+++ b/noaa.go
@@ -98,16 +98,18 @@ type ForecastResponsePeriod struct {
 
 // ForecastResponsePeriodHourly provides the JSON value for a period within an hourly forecast.
 type ForecastResponsePeriodHourly struct {
-	ID               int32  `json:"number"`
-	Name             string `json:"name"`
-	StartTime        string `json:"startTime"`
-	EndTime          string `json:"endTime"`
-	IsDaytime        bool   `json:"isDaytime"`
-	TemperatureTrend string `json:"temperatureTrend"`
-	WindDirection    string `json:"windDirection"`
-	Summary          string `json:"shortForecast"`
-	Icon             string `json:"icon,omitempty"`
-	Details          string `json:"detailedForecast"`
+	ID              int32   `json:"number"`
+	Name            string  `json:"name"`
+	StartTime       string  `json:"startTime"`
+	EndTime         string  `json:"endTime"`
+	IsDaytime       bool    `json:"isDaytime"`
+	Temperature     float64 `json:"temperature"`
+	TemperatureUnit string  `json:"temperatureUnit"`
+	WindSpeed       string  `json:"windSpeed"`
+	WindDirection   string  `json:"windDirection"`
+	Icon            string  `json:"icon"`
+	Summary         string  `json:"shortForecast"`
+	Details         string  `json:"detailedForecast"`
 }
 
 // ForecastResponse holds the JSON values from /gridpoints/<cwa>/<x,y>/forecast"


### PR DESCRIPTION
I missed some data in the hourly forecast when I coded this feature.  In particular, and most critically, the temperature and temperature unit was missing, and is provided in the hourly report.

After reading the OpenAPI 3.0 docs for this, it should be identical to ForecastResponsePeriod, even though in practice they don't return everything in the hourly that they do for the summary.

We could use ForecastResponsePeriod here if you'd prefer, or we could continue to use a separate structure, perhaps with a mind to culling the properties not actually returned in the hourly report.  I've changed this code to use the same structure, but the different type, so we have the option of culling properties if desired.