### PR TITLE
providing a way to use http client customizations

### DIFF
--- a/noaa.go
+++ b/noaa.go
@@ -22,6 +22,8 @@ const (
 // This defaults to the APIKey const value.
 var userAgent = APIKey
 
+var client = http.DefaultClient
+
 // PointsResponse holds the JSON values from /points/<lat,lon>
 type PointsResponse struct {
 	ID                          string `json:"@id"`
@@ -272,7 +274,7 @@ func apiCall(endpoint string) (res *http.Response, err error) {
 	req.Header.Add("Accept", APIAccept)
 	req.Header.Add("User-Agent", userAgent) // See http://www.weather.gov/documentation/services-web-api
 
-	res, err = http.DefaultClient.Do(req)
+	res, err = client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -423,4 +425,11 @@ func HourlyForecast(lat string, long string) (forecast *HourlyForecastResponse, 
 	}
 	forecast.Point = point
 	return forecast, nil
+}
+
+// SetClient sets the client for all API requests to use, returning the previous client used.
+func SetClient(preferred *http.Client) (result *http.Client) {
+	result = client
+	client = preferred
+	return
 }

--- a/noaa_test.go
+++ b/noaa_test.go
@@ -1,7 +1,9 @@
 package noaa_test
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/icodealot/noaa"
 )
@@ -95,5 +97,30 @@ func TestChicagoHourly(t *testing.T) {
 	}
 	if len(hourly.Periods) == 0 {
 		t.Error("expected at least one period")
+	}
+}
+
+func TestSetClient(t *testing.T) {
+	client := &http.Client{
+		Timeout: time.Millisecond * 1,
+	}
+	orig := noaa.SetClient(client)
+	if orig != http.DefaultClient {
+		t.Error("expected http.DefaultClient but got something else.")
+	}
+
+	_, err := noaa.HourlyForecast("41.837", "-87.685")
+	if err == nil {
+		t.Error("expected request to time out (1 millisecond is too brief for any request)")
+	}
+
+	myClient := noaa.SetClient(orig)
+	if myClient != client {
+		t.Error("expected client, but got something else.")
+	}
+
+	_, err = noaa.HourlyForecast("41.837", "-87.685")
+	if err != nil {
+		t.Error("noaa.HourlyForecast() should return valid data.")
 	}
 }


### PR DESCRIPTION
I ran into a situation where the use of http.DefaultClient causes huge problems in environments where the internet is spotty for long periods of time and one performs regular requests for weather information.

To fix this, one needs a way to cause the client to time out (by default, the client never times out, and the requests accumulate).

Unfortunately, the noaa library doesn't provide a way to do this, so I added a way that ought to help.
