### PR TITLE
provide a way to set the http.Client for requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,8 +10,7 @@ import (
 // Default values for the weather.gov REST API config which will
 // be replaced by Config. These are subject to deletion in the future.
 // Instead, use noaa.GetConfig followed by:
-//
-//	Config.BaseURL, Config.UserAgent, Config.Accept
+//	   Config.BaseURL, Config.UserAgent, Config.Accept
 const (
 	API       = "https://api.weather.gov"
 	APIKey    = "github.com/icodealot/noaa" // User-Agent default value
@@ -76,11 +75,10 @@ func SetUnits(uom string) {
 	}
 }
 
-// SetClient sets the http.Client used for requests, returning the previous client.
-func SetClient(client *http.Client) (result *http.Client) {
-	result = config.Client
+// SetClient sets the http.Client used for requests.
+// Setting this to nil causes the uses of http.DefaultClient.
+func SetClient(client *http.Client) {
 	config.Client = client
-	return
 }
 
 // SetConfig replaces the config with all new values in one call. The individual

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package noaa
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -9,7 +10,8 @@ import (
 // Default values for the weather.gov REST API config which will
 // be replaced by Config. These are subject to deletion in the future.
 // Instead, use noaa.GetConfig followed by:
-//     Config.BaseURL, Config.UserAgent, Config.Accept
+//
+//	Config.BaseURL, Config.UserAgent, Config.Accept
 const (
 	API       = "https://api.weather.gov"
 	APIKey    = "github.com/icodealot/noaa" // User-Agent default value
@@ -25,10 +27,11 @@ var config = GetDefaultConfig()
 // future weather.gov might change this behavior.
 // See http://www.weather.gov/documentation/services-web-api
 type Config struct {
-	BaseURL   string `json:"baseUrl"` // Do not include a trailing slash
-	UserAgent string `json:"apiKey"`  // ex. (myweatherapp.com, contact@myweatherapp.com)
-	Accept    string `json:"accept"`  // application/geo+json, etc. defaults to ld+json
-	Units     string `json:"units"`   // "us" (the default if blank) or "si" for metric
+	BaseURL   string       `json:"baseUrl"` // Do not include a trailing slash
+	UserAgent string       `json:"apiKey"`  // ex. (myweatherapp.com, contact@myweatherapp.com)
+	Accept    string       `json:"accept"`  // application/geo+json, etc. defaults to ld+json
+	Units     string       `json:"units"`   // "us" (the default if blank) or "si" for metric
+	Client    *http.Client `json:"-"`       // The client to use for requests (http.DefaultClient by default).
 }
 
 const (
@@ -73,6 +76,13 @@ func SetUnits(uom string) {
 	}
 }
 
+// SetClient sets the http.Client used for requests, returning the previous client.
+func SetClient(client *http.Client) (result *http.Client) {
+	result = config.Client
+	config.Client = client
+	return
+}
+
 // SetConfig replaces the config with all new values in one call. The individual
 // Set* functions can also be used to replace only specified values.
 func SetConfig(c Config) {
@@ -96,6 +106,7 @@ func GetDefaultConfig() Config {
 		UserAgent: APIKey,
 		Accept:    APIAccept,
 		Units:     "", // defaults to US units if unspecified
+		Client:    http.DefaultClient,
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -9,6 +9,8 @@ package noaa_test
 import (
 	"fmt"
 	"log"
+	"net/http"
+	"time"
 
 	"github.com/icodealot/noaa"
 )
@@ -174,6 +176,29 @@ func ExampleGetChicagoWeatherStations() {
 
 	// Output:
 	// Success!
+}
+
+func ExampleSetClient() {
+
+	// Cleanup global state before each example
+	beforeEachExample()
+
+	// Use a client that can't successfully make a request.
+	noaa.SetClient(&http.Client{
+		Timeout: time.Millisecond * 1,
+	})
+
+	// Get the hourly forecast for Chicago by lat/lon
+	_, err := noaa.Stations("41.837", "-87.685")
+	if err != nil {
+		fmt.Printf("Error getting the stations: %v", err)
+		return
+	}
+
+	fmt.Println("Success!")
+
+	// Output:
+	// Error getting the stations: Get "https://api.weather.gov/gridpoints/LOT/74,71/stations": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
 }
 
 // beforeEachExample is used to clean up the global state of the noaa client

--- a/http.go
+++ b/http.go
@@ -39,7 +39,12 @@ func get(endpoint string) (res *http.Response, err error) {
 	// enable quantitative values in forecast responses
 	req.Header.Add("feature-flags", "forecast_temperature_qv, forecast_wind_speed_qv")
 
-	res, err = http.DefaultClient.Do(req)
+	// lazy-init client to http.DefaultClient.
+	if config.Client == nil {
+		config.Client = http.DefaultClient
+	}
+
+	res, err = config.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/noaa_test.go
+++ b/noaa_test.go
@@ -114,17 +114,14 @@ func TestSetClient(t *testing.T) {
 		Timeout: time.Millisecond,
 	}
 
-	// Don't set client to ensure this still works as normal.
+	// Don't set the client, to ensure this still works as normal.
 	_, err := noaa.HourlyForecast("41.837", "-87.685")
 	if err != nil {
 		t.Errorf("should have successfully returned a result instead of this error: %s", err)
 	}
 
 	// Set the client to test this feature.
-	orig := noaa.SetClient(client)
-	if orig != nil && orig != http.DefaultClient {
-		t.Error("original client should have been nil or http.DefaultClient")
-	}
+	noaa.SetClient(client)
 
 	// See if we can make a (failing) request with this.
 	_, err = noaa.HourlyForecast("41.837", "-87.685")
@@ -132,13 +129,8 @@ func TestSetClient(t *testing.T) {
 		t.Error("should have failed the request, 1 millisecond is too short a timeout to make the request")
 	}
 
-	// nil or http.DefaultClient should return to the original client.
-	orig = noaa.SetClient(nil)
-	if orig != client {
-		t.Error("expected the client I passed in, but got something else.")
-	}
-
-	// Ensure we can still make requests after setting to nil.
+	// Test that setting to nil returns to http.DefaultClient.
+	noaa.SetClient(nil)
 	_, err = noaa.HourlyForecast("41.837", "-87.685")
 	if err != nil {
 		t.Errorf("should have successfully returned a result instead of this error: %s", err)

--- a/noaa_test.go
+++ b/noaa_test.go
@@ -10,7 +10,9 @@
 package noaa_test
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/icodealot/noaa"
 )
@@ -103,5 +105,42 @@ func TestChicagoHourly(t *testing.T) {
 	}
 	if len(hourly.Periods) == 0 {
 		t.Error("expected at least one period")
+	}
+}
+
+func TestSetClient(t *testing.T) {
+	// Intentionally create a client with an absurd timeout value.
+	client := &http.Client{
+		Timeout: time.Millisecond,
+	}
+
+	// Don't set client to ensure this still works as normal.
+	_, err := noaa.HourlyForecast("41.837", "-87.685")
+	if err != nil {
+		t.Errorf("should have successfully returned a result instead of this error: %s", err)
+	}
+
+	// Set the client to test this feature.
+	orig := noaa.SetClient(client)
+	if orig != nil && orig != http.DefaultClient {
+		t.Error("original client should have been nil or http.DefaultClient")
+	}
+
+	// See if we can make a (failing) request with this.
+	_, err = noaa.HourlyForecast("41.837", "-87.685")
+	if err == nil {
+		t.Error("should have failed the request, 1 millisecond is too short a timeout to make the request")
+	}
+
+	// nil or http.DefaultClient should return to the original client.
+	orig = noaa.SetClient(nil)
+	if orig != client {
+		t.Error("expected the client I passed in, but got something else.")
+	}
+
+	// Ensure we can still make requests after setting to nil.
+	_, err = noaa.HourlyForecast("41.837", "-87.685")
+	if err != nil {
+		t.Errorf("should have successfully returned a result instead of this error: %s", err)
 	}
 }


### PR DESCRIPTION
The current code base doesn't provide a way to set which http.Client to use for requests.

This causes problems in production environments if the network dies for an extended period of time, and the tool makes regular calls (hourly or so) for weather information, because the default client doesn't time out.

I've opened issue #11 for this problem.